### PR TITLE
Update Kotlin Plugins to 1.4.0-rc

### DIFF
--- a/kotlin-library/build.gradle.kts
+++ b/kotlin-library/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.multiplatform").version("1.4.255-SNAPSHOT")
-    id("org.jetbrains.kotlin.native.cocoapods").version("1.4.255-SNAPSHOT")
+    id("org.jetbrains.kotlin.multiplatform").version("1.4.0-rc")
+    id("org.jetbrains.kotlin.native.cocoapods").version("1.4.0-rc")
 }
 
 group = "com.example"


### PR DESCRIPTION
Use `1.4.0-rc` instead of `1.4.255-SNAPSHOT` for multiplatform and cocoapods plugin.